### PR TITLE
Add Autocluster plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Alpine Linux RabbitMQ Docker image
-Many other RabbitMQ Docker images are [huge](https://imagelayers.io/?images=rabbitmq:latest,frodenas%2Frabbitmq:latest,tutum%2Frabbitmq:latest).  Instead of using the bloated Ubuntu or Fedora images as a base, this image uses the 5MB Alpine Linux base image.  Alpine lets us run RabbitMQ 3.6.0 on Erlang 18.1 in only **27MB**!
+Many other RabbitMQ Docker images are [huge](https://imagelayers.io/?images=rabbitmq:latest,frodenas%2Frabbitmq:latest,tutum%2Frabbitmq:latest).  Instead of using the bloated Ubuntu or Fedora images as a base, this image uses the 5MB Alpine Linux base image.  Alpine lets us run RabbitMQ 3.6.0 on Erlang 18.1 in only **37MB**!
 
 ### Usage
 The wrapper script starts RabbitMQ (with management plugin enabled), tails the log, and configures listeners on the standard ports:
@@ -10,11 +10,21 @@ The wrapper script starts RabbitMQ (with management plugin enabled), tails the l
 
 RabbitMQ's data is persisted to a volume at `/var/lib/rabbitmq`.
 
-To enable SSL set the `$SSL_CERT_FILE`, `$SSL_KEY_FILE`, and `$SSL_CA_FILE` environment variables.  The wrapper script will use the same certs for GUI SSL access as for AMQPS access.
+To enable SSL set the `SSL_CERT_FILE`, `SSL_KEY_FILE`, and `SSL_CA_FILE` environment variables.  The wrapper script will use the same certs for GUI SSL access as for AMQPS access.
 
+**2/10/16**: We've added the [autocluster](https://github.com/aweber/rabbitmq-autocluster) plugin to this image. To enable it, set the `AUTOCLUSTER_TYPE` environment variable to your backend (we've tested with Consul). See the autocluster [docs](https://github.com/aweber/rabbitmq-autocluster#configuration) for details on what additional options can be set for provided backends.
 
-*Example:*
+***Examples:***
+```bash
+# Run without TLS
+docker run -d \
+  --name rabbitmq \
+  -p 5672:5672 \
+  -p 15672:15672 \
+  gonkulatorlabs/rabbitmq
 ```
+
+```bash
 # Run with TLS enabled
 docker run -it \
   --name rabbitmq \
@@ -26,17 +36,23 @@ docker run -it \
   gonkulatorlabs/rabbitmq
 ```
 
-```
-# Run without TLS
+```bash
+# Run with autoclustering enabled
+#   These options will register the RMQ
+#   node as living on 192.168.99.101.
+#   Nodes that join will attempt to cluster
+#   on that address.
 docker run -d \
   --name rabbitmq \
+  -e AUTOCLUSTER_TYPE=consul \
+  -e CONSUL_HOST=192.168.99.101 \
   -p 5672:5672 \
   -p 15672:15672 \
   gonkulatorlabs/rabbitmq
 ```
 
 ### Customizing
-To set a custom config, ditch the wrapper script and call `rabbitmq-server` directly.  Place the custom config in `/srv/rabbitmq_server-3.6.0/etc/rabbitmq/`.
+To set a custom config, ditch the wrapper script and call `rabbitmq-server` directly.  Place the custom config in `/srv/rabbitmq_server-3.6.0/etc/rabbitmq/`. To reduce startup complexity, the autocluster plugin is not enabled by default (our wrapper script enables it on demand). If you want to use it with a custom config, make sure to run `rabbitmq-plugins enable --offline autocluster` in the container before starting Rabbit.
 
 ### Fair Warning!
 Alpine's Erlang packages are in its `edge` (testing) repo, if that bothers you then don't use this image!

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -26,6 +26,10 @@ if ! [[ -z ${SSL_CA_FILE+x} ]]; then
     sed -i "s,CAFILE,$SSL_CA_FILE,g" ${RABBITMQ_HOME}/etc/rabbitmq/ssl.config
 fi
 
+if ! [[ -z ${AUTOCLUSTER_TYPE+x} ]]; then
+    rabbitmq-plugins enable --offline autocluster
+fi
+
 if [[ "${use_ssl}" == "yes" ]]; then
     mkdir -p /opt || true
     # Create combined cert
@@ -51,15 +55,15 @@ fi
 
 # RMQ server process so we can tail the logs
 # to the same stdout
-${RABBITMQ_HOME}/sbin/rabbitmq-server &
+rabbitmq-server &
 
 # Capture the PID
 rmq_pid=$!
 
 # Tail the logs, but continue on to the wait command
-echo -e "\n\nTailing log output:"
+echo "Tailing log output:"
 tail -F ${RABBITMQ_HOME}/var/log/rabbitmq/rabbit@${HOSTNAME}.log \
-     -F ${RABBITMQ_HOME}/var/log/rabbitmq/rabbit@${HOSTNAME}-sasl.log &
+     -F ${RABBITMQ_HOME}/var/log/rabbitmq/rabbit@${HOSTNAME}-sasl.log 2> /dev/null &
 
 # If RMQ dies, this script dies
-wait $rmq_pid
+wait $rmq_pid 2> /dev/null


### PR DESCRIPTION
Adding support for https://github.com/aweber/rabbitmq-autocluster. The wrapper script now checks for `AUTOCLUSTER_TYPE` and enables the plugin if it's found. All other configuration is expected to be done via the ENV, per autocluster's docs.

Small additional changes:
- Parameterized the RMQ (and autocluster) versions in the Dockerfile
- Added `$RABBITMQ_HOME/sbin` to `PATH`
- Updated the readme to accurately reflect the size of the image (37MB)
