### PR TITLE
Fix for #7

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -49,7 +49,8 @@ if [[ "${use_ssl}" == "yes" ]]; then
         ${RABBITMQ_HOME}/etc/rabbitmq/rabbitmq.config
 else
     echo "Launching RabbitMQ..."
-    mv ${RABBITMQ_HOME}/etc/rabbitmq/standard.config \
+    [[ -f ${RABBITMQ_HOME}/etc/rabbitmq/rabbitmq.config ]] || mv \
+        ${RABBITMQ_HOME}/etc/rabbitmq/standard.config \
         ${RABBITMQ_HOME}/etc/rabbitmq/rabbitmq.config
 fi
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -45,7 +45,8 @@ if [[ "${use_ssl}" == "yes" ]]; then
 
     echo "Launching RabbitMQ with SSL..."
     echo -e " - SSL_CERT_FILE: $SSL_CERT_FILE\n - SSL_KEY_FILE: $SSL_KEY_FILE\n - SSL_CA_FILE: $SSL_CA_FILE"
-    mv ${RABBITMQ_HOME}/etc/rabbitmq/ssl.config \
+    [[ -f ${RABBITMQ_HOME}/etc/rabbitmq/rabbitmq.config ]] || mv \
+        ${RABBITMQ_HOME}/etc/rabbitmq/ssl.config \
         ${RABBITMQ_HOME}/etc/rabbitmq/rabbitmq.config
 else
     echo "Launching RabbitMQ..."


### PR DESCRIPTION
Added checks to see if `${RABBITMQ_HOME}/etc/rabbitmq/rabbitmq.config` exists before copying the template there. Resolves #7 .
