### PR TITLE
3.6.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,21 +18,23 @@ EXPOSE      5671/tcp 5672/tcp 15672/tcp 15671/tcp
 VOLUME      /var/lib/rabbitmq
 CMD         ["/usr/bin/wrapper"]
 
-RUN         chmod a+x /usr/bin/wrapper && apk add --update curl tar xz bash && \
-            for p in erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl erlang-sasl \
+RUN         for p in erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl erlang-sasl \
                 erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap erlang-syntax-tools;do \
-                apk add ${p}=$ERLANG_VERSION; done && \
+                ERLS="$ERLS $p=$ERLANG_VERSION"; done && \
+            chmod a+x /usr/bin/wrapper && \
+            apk add --update curl bash $ERLS && \
             cd /srv && \
             rmq_zip_url=https://github.com/rabbitmq/rabbitmq-server/releases/download && \
                 rmq_zip_url=${rmq_zip_url}/rabbitmq_v$(echo $RABBITMQ_VERSION | tr '.' '_') && \
                 rmq_zip_url=${rmq_zip_url}/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.xz && \
             curl -L -o /srv/rmq.tar.xz $rmq_zip_url && \
-            tar -xvf rmq.tar.xz && rm -f rmq.tar.xz && \
+            tar -x -f rmq.tar.xz && rm -f rmq.tar.xz && \
             touch /srv/rabbitmq_server-${RABBITMQ_VERSION}/etc/rabbitmq/enabled_plugins && \
             rabbitmq-plugins enable --offline rabbitmq_management && \
             rmq_ac_url=https://github.com/aweber/rabbitmq-autocluster/releases/download && \
                 rmq_ac_url=${rmq_ac_url}/${RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION} && \
-                rmq_ac_url=${rmq_ac_url}/autocluster-${RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION}.ez && \
-            curl -Lv -o ${PLUGINS_DIR}/autocluster-${RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION}.ez $rmq_ac_url && \
-            apk del --purge tar xz && rm -Rf /var/cache/apk/* && \
+                rmq_ac_url=${rmq_ac_url}/autocluster-${RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION}.tgz && \
+            curl -L -o /tmp/autocluster-${RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION}.tgz $rmq_ac_url && \
+            tar -x -C ${PLUGINS_DIR} -f /tmp/autocluster-${RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION}.tgz && \
+            rm -Rf /var/cache/apk/*  /tmp/* && \
             ln -sf $RABBITMQ_HOME /rabbitmq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM        alpine
-MAINTAINER  Gonkulator Labs <github.com/gonkulator>
+FROM        alpine:latest
+MAINTAINER  Maryville Technologies <github.com/maryvilledev>
 
 ENV         RABBITMQ_VERSION=3.6.5 \
             RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION=0.6.1
 ENV         RABBITMQ_HOME=/srv/rabbitmq_server-${RABBITMQ_VERSION} \
             PLUGINS_DIR=/srv/rabbitmq_server-${RABBITMQ_VERSION}/plugins \
             ENABLED_PLUGINS_FILE=/srv/rabbitmq_server-${RABBITMQ_VERSION}/etc/rabbitmq/enabled_plugins \
-            RABBITMQ_MNESIA_BASE=/var/lib/rabbitmq
+            RABBITMQ_MNESIA_BASE=/var/lib/rabbitmq \
+            ERLANG_VERSION=18.3.2-r0
 ENV         PATH=$PATH:$RABBITMQ_HOME/sbin
 
 COPY        ssl.config /srv/rabbitmq_server-${RABBITMQ_VERSION}/etc/rabbitmq/
@@ -18,17 +19,14 @@ VOLUME      /var/lib/rabbitmq
 CMD         ["/usr/bin/wrapper"]
 
 RUN         chmod a+x /usr/bin/wrapper && apk add --update curl tar xz bash && \
-            echo "http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-            echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-            echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-            apk add erlang erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl \
-                erlang-sasl erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap \
-                erlang-syntax-tools --update-cache --allow-untrusted && \
+            for p in erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl erlang-sasl \
+                erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap erlang-syntax-tools;do \
+                apk add ${p}=$ERLANG_VERSION; done && \
             cd /srv && \
             rmq_zip_url=https://github.com/rabbitmq/rabbitmq-server/releases/download && \
                 rmq_zip_url=${rmq_zip_url}/rabbitmq_v$(echo $RABBITMQ_VERSION | tr '.' '_') && \
                 rmq_zip_url=${rmq_zip_url}/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.xz && \
-            curl -Lv -o /srv/rmq.tar.xz $rmq_zip_url && \
+            curl -L -o /srv/rmq.tar.xz $rmq_zip_url && \
             tar -xvf rmq.tar.xz && rm -f rmq.tar.xz && \
             touch /srv/rabbitmq_server-${RABBITMQ_VERSION}/etc/rabbitmq/enabled_plugins && \
             rabbitmq-plugins enable --offline rabbitmq_management && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM        alpine:3.2
+FROM        alpine
 MAINTAINER  Gonkulator Labs <github.com/gonkulator>
 
-ENV         RABBITMQ_VERSION=3.6.1 \
-            RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION=0.4.1
+ENV         RABBITMQ_VERSION=3.6.5 \
+            RABBITMQ_AUTOCLUSTER_PLUGIN_VERSION=0.6.1
 ENV         RABBITMQ_HOME=/srv/rabbitmq_server-${RABBITMQ_VERSION} \
             PLUGINS_DIR=/srv/rabbitmq_server-${RABBITMQ_VERSION}/plugins \
             ENABLED_PLUGINS_FILE=/srv/rabbitmq_server-${RABBITMQ_VERSION}/etc/rabbitmq/enabled_plugins \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Alpine Linux RabbitMQ Docker image
-Many other RabbitMQ Docker images are [huge](https://imagelayers.io/?images=rabbitmq:latest,frodenas%2Frabbitmq:latest,tutum%2Frabbitmq:latest).  Instead of using the bloated Ubuntu or Fedora images as a base, this image uses the 5MB Alpine Linux base image.  Alpine lets us run RabbitMQ 3.6.1 on Erlang 18.3.2 in only **37MB**!
+RabbitMQ 3.6.5 on Alpine + Erlang 18.3.2 in only **35MB**!
 
 ### Usage
 The wrapper script starts RabbitMQ (with management plugin enabled), tails the log, and configures listeners on the standard ports:


### PR DESCRIPTION
- Fix the autocluster plugin
- bump to 3.6.5
- hold erlang back to 18.3.2 because of issue with 19.1 in the edge repo